### PR TITLE
add makefile support, for all tasks

### DIFF
--- a/qorc_fpga_breathectrl/.scaffolding/build_fpga.sh
+++ b/qorc_fpga_breathectrl/.scaffolding/build_fpga.sh
@@ -37,7 +37,7 @@ usage()
 while true ; do
     case "$1" in
         --qorc-sdk-path )
-            QORC_SDK_PATH="$2"
+            ARG_QORC_SDK_PATH="$2"
             shift 2
         ;;        
         -- )
@@ -52,20 +52,30 @@ while true ; do
 done
 
 # arg checks
-if [ -z "$QORC_SDK_PATH" ] ; then
-    printf "\nWARNING: QORC_SDK_PATH is not defined!\n"
+if [ -z "$ARG_QORC_SDK_PATH" ] ; then
+    # check if QORC_SDK_PATH is already setup (source envsetup.sh has already been invoked in the current shell)
+    if [ -z "$QORC_SDK_PATH" ] ; then
+        printf "\nERROR: QORC_SDK_PATH is not set in env, AND --qorc-sdk-path is not passed in!\n\n"
+        printf "    run source envsetup.sh from the QORC SDK directory in the current shell\n"
+        printf "    >>OR<<\n"
+        printf "    set the QORC SDK PATH using the --qorc-sdk-path=/path/to/qorc-sdk parameter\n\n"
+        exit 1
+    fi
 fi
 
 
 # confirmation print
 printf "\n"
-printf "QORC_SDK_PATH=$QORC_SDK_PATH\n"
+printf "ARG_QORC_SDK_PATH=$ARG_QORC_SDK_PATH\n"
 printf "\n"
 ################################################################################
 
-# setup QORC_SDK environment
-if [ ! -z "$QORC_SDK_PATH" ] ; then
-    cd $QORC_SDK_PATH
+
+# setup QORC_SDK environment, if needed.
+# we check that the QORC_SDK_PATH env variable is not already set, only then we need to do this,
+# because source envsetup.sh sets the QORC_SDK_PATH env variable.
+if [ -z "$QORC_SDK_PATH" ] ; then
+    cd $ARG_QORC_SDK_PATH
     source envsetup.sh
     cd - > /dev/null
 fi
@@ -96,6 +106,6 @@ PROJECT_DEVICE="ql-eos-s3"
 # note: for m4-fpga-standalone projects, fpga is built independently, always specify dump binary (and openocd,jlink for debugging or loading over SWD)
 
 printf "running symbiflow command:\n\n"
-printf "ql_symbiflow -compile -src "$PROJECT_RTL_DIR" -d "$PROJECT_DEVICE" -t "$PROJECT_TOP_MODULE" -v "$PROJECT_VERILOG_FILES" -p "$PROJECT_PCF_FILE" -P "$PROJECT_PACKAGE" -dump binary openocd jlink\n\n"
+printf "ql_symbiflow -compile -src $PROJECT_RTL_DIR -d $PROJECT_DEVICE -t $PROJECT_TOP_MODULE -v $PROJECT_VERILOG_FILES -p $PROJECT_PCF_FILE -P $PROJECT_PACKAGE -dump binary openocd jlink\n\n"
 
 ql_symbiflow -compile -src "$PROJECT_RTL_DIR" -d "$PROJECT_DEVICE" -t "$PROJECT_TOP_MODULE" -v "$PROJECT_VERILOG_FILES" -p "$PROJECT_PCF_FILE" -P "$PROJECT_PACKAGE" -dump binary openocd jlink

--- a/qorc_fpga_breathectrl/.scaffolding/flash_fpga_m4.sh
+++ b/qorc_fpga_breathectrl/.scaffolding/flash_fpga_m4.sh
@@ -36,7 +36,7 @@ usage()
 while true ; do
     case "$1" in
         --qorc-sdk-path )
-            QORC_SDK_PATH="$2"
+            ARG_QORC_SDK_PATH="$2"
             shift 2
         ;;
         --port )
@@ -55,8 +55,15 @@ while true ; do
 done
 
 # arg checks
-if [ -z "$QORC_SDK_PATH" ] ; then
-    printf "\nWARNING: QORC_SDK_PATH is not defined!\n"
+if [ -z "$ARG_QORC_SDK_PATH" ] ; then
+    # check if QORC_SDK_PATH is already setup (source envsetup.sh has already been invoked in the current shell)
+    if [ -z "$QORC_SDK_PATH" ] ; then
+        printf "\nERROR: QORC_SDK_PATH is not set in env, AND --qorc-sdk-path is not passed in!\n\n"
+        printf "    run source envsetup.sh from the QORC SDK directory in the current shell\n"
+        printf "    >>OR<<\n"
+        printf "    set the QORC SDK PATH using the --qorc-sdk-path=/path/to/qorc-sdk parameter\n\n"
+        exit 1
+    fi
 fi
 
 if [ -z "$PORT" ] ; then
@@ -68,13 +75,17 @@ fi
 
 # confirmation print
 printf "\n"
-printf "QORC_SDK_PATH=$QORC_SDK_PATH\n"
+printf "ARG_QORC_SDK_PATH=$ARG_QORC_SDK_PATH\n"
+printf "PORT=$PORT\n"
 printf "\n"
 ################################################################################
 
-# setup QORC_SDK environment
-if [ ! -z "$QORC_SDK_PATH" ] ; then
-    cd $QORC_SDK_PATH
+
+# setup QORC_SDK environment, if needed.
+# we check that the QORC_SDK_PATH env variable is not already set, only then we need to do this,
+# because source envsetup.sh sets the QORC_SDK_PATH env variable.
+if [ -z "$QORC_SDK_PATH" ] ; then
+    cd $ARG_QORC_SDK_PATH
     source envsetup.sh
     cd - > /dev/null
 fi

--- a/qorc_fpga_breathectrl/.scaffolding/load_fpga_m4_jlink.sh
+++ b/qorc_fpga_breathectrl/.scaffolding/load_fpga_m4_jlink.sh
@@ -82,9 +82,11 @@ printf "\n"
 
 
 
-PROJECT_ROOT_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
+PROJECT_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
+PROJECT_M4_DIR="${PROJECT_DIR}/GCC_Project"
+PROJECT_FPGA_DIR="${PROJECT_DIR}/fpga"
 
-PROJECT_OUTPUT_BIN_DIR="${PROJECT_ROOT_DIR}/GCC_Project/output/bin"
+PROJECT_OUTPUT_BIN_DIR="${PROJECT_DIR}/GCC_Project/output/bin"
 PROJECT_M4_BIN=$(ls "$PROJECT_OUTPUT_BIN_DIR"/*.bin)
 
 if [ ! -f "$PROJECT_M4_BIN" ] ; then
@@ -92,7 +94,7 @@ if [ ! -f "$PROJECT_M4_BIN" ] ; then
     exit 1
 fi
 
-PROJECT_RTL_DIR="${PROJECT_ROOT_DIR}/fpga/rtl"
+PROJECT_RTL_DIR="${PROJECT_DIR}/fpga/rtl"
 PROJECT_FPGA_DESIGN_JLINK=$(ls "$PROJECT_RTL_DIR"/*.jlink)
 
 if [ ! -f "$PROJECT_FPGA_DESIGN_JLINK" ] ; then

--- a/qorc_fpga_breathectrl/.scaffolding/load_fpga_m4_openocd_gdb.sh
+++ b/qorc_fpga_breathectrl/.scaffolding/load_fpga_m4_openocd_gdb.sh
@@ -14,7 +14,7 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 OPENOCD_PATH=$(which openocd)
-OPENOCD_INTERFACE_CFG="jlink_swd.cfg"
+OPENOCD_INTERFACE_CFG=
 GDB_PATH=$(which arm-none-eabi-gdb)
 ################################################################################
 #   getopt based parsing

--- a/qorc_fpga_breathectrl/.vscode/c_cpp_properties.json
+++ b/qorc_fpga_breathectrl/.vscode/c_cpp_properties.json
@@ -58,7 +58,8 @@
             "compileCommands": "${workspaceFolder}/GCC_Project/compile_commands.json",
             "cStandard": "c99",
             "cppStandard": "c++11",
-            "intelliSenseMode": "gcc-arm"
+            "intelliSenseMode": "gcc-arm",
+            "configurationProvider": "ms-vscode.makefile-tools"
         }
     ],
     "version": 4

--- a/qorc_fpga_breathectrl/.vscode/launch.json
+++ b/qorc_fpga_breathectrl/.vscode/launch.json
@@ -6,7 +6,7 @@
             "name": "Debug (OpenOCD)",
             "type": "cortex-debug",
             "request": "launch",
-            "cwd": "${workspaceFolder}/.scaffolding",
+            "cwd": "${workspaceFolder}",
             "executable": "${workspaceFolder}/GCC_Project/output/bin/${workspaceFolderBasename}.elf",
             "runToEntryPoint": "main",
             "interface": "swd",
@@ -53,7 +53,7 @@
             "name": "Debug (JLink)",
             "type": "cortex-debug",
             "request": "launch",
-            "cwd": "${workspaceFolder}/.scaffolding",
+            "cwd": "${workspaceFolder}",
             "executable": "${workspaceFolder}/GCC_Project/output/bin/${workspaceFolderBasename}.elf",
             "runToEntryPoint": "main",
             "interface": "swd",
@@ -75,12 +75,12 @@
             "description": "select debug probe to use with OpenOCD",
             "type": "pickString",
             "options": [
-                "jlink_swd.cfg",
-                "ft2232h_swd.cfg",
+                ".scaffolding/jlink_swd.cfg",
+                ".scaffolding/ft2232h_swd.cfg",
                 "interface/stlink-v2.cfg",
                 "interface/cmsis-dap.cfg"
             ],
-            "default": "jlink_swd.cfg"
+            "default": ".scaffolding/jlink_swd.cfg",
         }
     ]
 }

--- a/qorc_fpga_breathectrl/.vscode/tasks.json
+++ b/qorc_fpga_breathectrl/.vscode/tasks.json
@@ -33,9 +33,9 @@
             // build-m4 : invoke make to build the cortex-m4 code
             "label": "build-m4",
             "type": "shell",
-            "command": "cd ${config:qorc_sdk_path} && source envsetup.sh && cd - && make",
+            "command": "source ${config:qorc_sdk_path}/envsetup.sh && make m4",
             "options": {
-                "cwd": "${workspaceFolder}/GCC_Project",
+                "cwd": "${workspaceFolder}",
             },
             "group": "build",
             "problemMatcher": {
@@ -63,9 +63,9 @@
             // clean-m4 : invoke make clean to clean the cortex-m4 code
             "label": "clean-m4",
             "type": "shell",
-            "command": "cd ${config:qorc_sdk_path} && source envsetup.sh && cd - && make clean",
+            "command": "source ${config:qorc_sdk_path}/envsetup.sh && make clean-m4",
             "options": {
-                "cwd": "${workspaceFolder}/GCC_Project"
+                "cwd": "${workspaceFolder}"
             },
             "group": "build",
             "problemMatcher": {
@@ -81,9 +81,9 @@
             // build-fpga : invoke ql_symbiflow to build verilog code
             "label": "build-fpga",
             "type": "shell",
-            "command": "./build_fpga.sh --qorc-sdk-path=${config:qorc_sdk_path}",
+            "command": "source ${config:qorc_sdk_path}/envsetup.sh && make fpga",
             "options": {
-                "cwd": "${workspaceFolder}/.scaffolding"
+                "cwd": "${workspaceFolder}"
             },
             "group": "build",
             "problemMatcher": [],
@@ -98,9 +98,9 @@
             // clean-fpga : remove fpga build artifacts
             "label": "clean-fpga",
             "type": "shell",
-            "command": "./clean_fpga.sh --qorc-sdk-path=${config:qorc_sdk_path}",
+            "command": "source ${config:qorc_sdk_path}/envsetup.sh && make clean-fpga",
             "options": {
-                "cwd": "${workspaceFolder}/.scaffolding"
+                "cwd": "${workspaceFolder}"
             },
             "group": "build",
             "problemMatcher": [],
@@ -116,9 +116,9 @@
             // Otherwise, run the script as in the command: "" below directly in bash shell to flash.
             "label": "flash-fpga-m4",
             "type": "shell",
-            "command": "./flash_fpga_m4.sh --qorc-sdk-path=${config:qorc_sdk_path} --port=${input:serialPortFromExt}",
+            "command": "source ${config:qorc_sdk_path}/envsetup.sh && make flash QORC_PORT=${input:serialPortFromExt}",
             "options": {
-                "cwd": "${workspaceFolder}/.scaffolding"
+                "cwd": "${workspaceFolder}"
             },
             "problemMatcher": [],
             "presentation": {
@@ -136,9 +136,9 @@
             // load-fpga-m4 : load the fpga and m4 images into EOS_S3 using OpenOCD and a selectable probe
             "label": "load-fpga-m4 (OpenOCD)",
             "type": "shell",
-            "command": "./load_fpga_m4_openocd_gdb.sh --openocd-path=${config:qorc_openocd_server_path} --openocd-if-cfg=${input:openocdProbe} --gdb-path=${config:qorc_arm_toolchain_path}/arm-none-eabi-gdb",
+            "command": "source ${config:qorc_sdk_path}/envsetup.sh && make load-openocd OPENOCD_IF_CFG=${input:openocdProbe}",
             "options": {
-                "cwd": "${workspaceFolder}/.scaffolding"
+                "cwd": "${workspaceFolder}"
             },
             "problemMatcher": [],
             "presentation": {
@@ -156,9 +156,9 @@
             // load-fpga-m4 : load the fpga and m4 images into EOS_S3 using JLink Commander and a JLink probe
             "label": "load-fpga-m4 (JLink)",
             "type": "shell",
-            "command": "./load_fpga_m4_jlink.sh --jlink-exe-path=${config:qorc_jlink_commander_path}",
+            "command": "source ${config:qorc_sdk_path}/envsetup.sh && make load-jlink",
             "options": {
-                "cwd": "${workspaceFolder}/.scaffolding"
+                "cwd": "${workspaceFolder}"
             },
             "group": "build",
             "problemMatcher": [],
@@ -181,9 +181,9 @@
             "label": "debug-load-fpga (JLink)",
             "detail": "run this task *after* entrypoint main is hit when debugging with JLink GDB Server",
             "type": "shell",
-            "command": "./debug_load_fpga_jlink.sh --jlink-exe-path=${config:qorc_jlink_commander_path}",
+            "command": "source ${config:qorc_sdk_path}/envsetup.sh && .scaffolding/debug_load_fpga_jlink.sh",
             "options": {
-                "cwd": "${workspaceFolder}/.scaffolding"
+                "cwd": "${workspaceFolder}"
             },
             "problemMatcher": [],
             "presentation": {
@@ -207,7 +207,7 @@
             "label": "generate-json-db",
             "detail": "generate compile_commands.json using bear",
             "type": "shell",
-            "command": "cd ${config:qorc_sdk_path} && source envsetup.sh && cd - && make clean && bear make",
+            "command": "source ${config:qorc_sdk_path}/envsetup.sh && make clean && bear make",
             "options": {
                 "cwd": "${workspaceFolder}/GCC_Project"
             },
@@ -243,12 +243,12 @@
             "description": "select debug probe to use with OpenOCD",
             "type": "pickString",
             "options": [
-                "jlink_swd.cfg",
-                "ft2232h_swd.cfg",
+                ".scaffolding/jlink_swd.cfg",
+                ".scaffolding/ft2232h_swd.cfg",
                 "interface/stlink-v2.cfg",
                 "interface/cmsis-dap.cfg"
             ],
-            "default": "jlink_swd.cfg"
+            "default": ".scaffolding/jlink_swd.cfg"
         }
     ],
 }

--- a/qorc_fpga_breathectrl/.vscode/tasks.json
+++ b/qorc_fpga_breathectrl/.vscode/tasks.json
@@ -114,7 +114,7 @@
             // flash-fpga-m4 : flash the fpga and m4 images into the board's flash via UART
             // !!!NOTE: ensure that python is available on PATH, and pySerial is installed!!!
             // Otherwise, run the script as in the command: "" below directly in bash shell to flash.
-            "label": "flash-fpga-m4",
+            "label": "flash",
             "type": "shell",
             "command": "source ${config:qorc_sdk_path}/envsetup.sh && make flash QORC_PORT=${input:serialPortFromExt}",
             "options": {
@@ -134,9 +134,9 @@
         },
         {
             // load-fpga-m4 : load the fpga and m4 images into EOS_S3 using OpenOCD and a selectable probe
-            "label": "load-fpga-m4 (OpenOCD)",
+            "label": "load (OpenOCD)",
             "type": "shell",
-            "command": "source ${config:qorc_sdk_path}/envsetup.sh && make load-openocd OPENOCD_IF_CFG=${input:openocdProbe}",
+            "command": "source ${config:qorc_sdk_path}/envsetup.sh && make load-openocd QORC_OCD_IF_CFG=${input:openocdProbe}",
             "options": {
                 "cwd": "${workspaceFolder}"
             },
@@ -154,7 +154,7 @@
         },
         {
             // load-fpga-m4 : load the fpga and m4 images into EOS_S3 using JLink Commander and a JLink probe
-            "label": "load-fpga-m4 (JLink)",
+            "label": "load (JLink)",
             "type": "shell",
             "command": "source ${config:qorc_sdk_path}/envsetup.sh && make load-jlink",
             "options": {

--- a/qorc_fpga_breathectrl/GCC_Project/config-GCC.mk
+++ b/qorc_fpga_breathectrl/GCC_Project/config-GCC.mk
@@ -11,7 +11,7 @@ export AS_FLAGS= -mcpu=cortex-m4 -mthumb -mlittle-endian -mfloat-abi=hard -mfpu=
 
 #Preprocessor macros
 
-export MACROS=-D__FPU_USED=1 -D__FPU_USED=1 \
+export MACROS=-D__FPU_USED=1 \
         -D__M4_DEBUG \
         -D__EOSS3_CHIP \
         -D__RTOS \
@@ -58,10 +58,11 @@ export CFLAGS= $(MACROS) \
 export LD_FLAGS_1= -mcpu=cortex-m4 -mthumb -mlittle-endian -mfloat-abi=hard -mfpu=fpv4-sp-d16 \
             ${DASH_O} $(OPT_FLAGS) -fmessage-length=0 -fsigned-char -ffunction-sections -fdata-sections  \
             ${DASH_G} -T "$(PROJ_DIR)/quickfeather.ld" -Xlinker --gc-sections -Wall -Werror \
-	-Wl,--fatal-warnings -Wl,-Map,"$(OUTPUT_PATH)/$(OUTPUT_FILE).map" \
+            -Wl,--fatal-warnings -Wl,-Map,"$(OUTPUT_PATH)/$(OUTPUT_FILE).map" \
+            -Wl,--print-memory-usage \
             --specs=nano.specs --specs=nosys.specs -Wl,--no-wchar-size-warning \
-            -o "$(OUTPUT_PATH)/$(OUTPUT_FILE).elf" -lm\
-    -L$(LIBCMSIS_GCC_DIR) -larm_cortexM4lf_math 
+            -o "$(OUTPUT_PATH)/$(OUTPUT_FILE).elf" -lm \
+            -L$(LIBCMSIS_GCC_DIR) -larm_cortexM4lf_math 
 
 
 export ELF2BIN_OPTIONS=-O binary

--- a/qorc_fpga_breathectrl/GCC_Project/config.mk
+++ b/qorc_fpga_breathectrl/GCC_Project/config.mk
@@ -119,6 +119,7 @@ export LD="$(QORC_TC_PATH)\arm-none-eabi-gcc"
 export AS="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
 export CC="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
 export ELF2BIN="$(QORC_TC_PATH)\arm-none-eabi-objcopy"
+export SIZE="$(QORC_TC_PATH)\arm-none-eabi-size"
 ################
 else
 ################ Linux ###################
@@ -169,6 +170,7 @@ export LD="$(QORC_TC_PATH)/arm-none-eabi-gcc"
 export AS="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
 export CC="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
 export ELF2BIN="$(QORC_TC_PATH)/arm-none-eabi-objcopy"
+export SIZE="$(QORC_TC_PATH)/arm-none-eabi-size"
 ################
 endif
 ################

--- a/qorc_fpga_breathectrl/GCC_Project/makefiles/Makefile_common
+++ b/qorc_fpga_breathectrl/GCC_Project/makefiles/Makefile_common
@@ -3,11 +3,10 @@
 
 D_FILES:=$(addprefix $(DEPEND_PATH)$(DIR_SEP),$(SRCS:.c=.d))
 O_FILES:=$(addprefix $(OUTPUT_PATH)$(DIR_SEP),$(SRCS:.c=.o))
-R_FILES:=$(addprefix $(MAIN_FPGA_RTL_DIR)$(DIR_SEP),$(FPGA_RTL_SRCS))
 
 DEPFLAGS = -MT $@ -MMD -MP -MF $(DEPEND_PATH)/$*.d
 
-all: $(OBJS) $(MAIN_FPGA_RTL_DIR)/$(FPGA_RTL_OBJ)
+all: $(OBJS)
 
 #$(info QLFS SOURCE: ${SRCS})
 #$(info QLFS OBJS: ${OBJS})
@@ -18,10 +17,6 @@ all: $(OBJS) $(MAIN_FPGA_RTL_DIR)/$(FPGA_RTL_OBJ)
 $(OUTPUT_PATH)/%.o: $(SRC_PATH)/%.c $(DEPEND_PATH)/%.d
 	$(CC) $< $(CFLAGS) $(DEPFLAGS) $(INCLUDE_DIRS) -o $@
 	
-SYMBIFLOW_WARN_PATTERN="^Warning [0-9]\{1,\}:.*no timing specification"
-$(MAIN_FPGA_RTL_DIR)/$(FPGA_RTL_OBJ): $(R_FILES)
-	time ql_symbiflow  -compile -src $(MAIN_FPGA_RTL_DIR) -d ql-eos-s3 -t $(RTL_TOP_MODULE) -v $(FPGA_RTL_SRCS) -p quickfeather.pcf -P PU64 -dump binary jlink openocd | grep -v $(SYMBIFLOW_WARN_PATTERN)
-
 -include $(D_FILES))
 	
 

--- a/qorc_fpga_breathectrl/GCC_Project/quickfeather.ld
+++ b/qorc_fpga_breathectrl/GCC_Project/quickfeather.ld
@@ -5,9 +5,6 @@ MEMORY
 {
 	rom (rx)  : ORIGIN = 0x00000000, LENGTH = 0x00027000
 	ram (rwx) : ORIGIN = 0x20027000, LENGTH = 0x0003c800
-	spiram (rw) : ORIGIN = 0x20063800, LENGTH = 0x0000800
-	HWA (rw)  : ORIGIN = 0x20064000, LENGTH = 0x00018000
-	shm       : ORIGIN = 0x2007C000, LENGTH = 0x00004000
 }
 
 SECTIONS
@@ -95,12 +92,6 @@ SECTIONS
 		_edata = __data_end__;
 	} > ram AT > rom
 
-	.Hardware (NOLOAD) :
-	{
-	  __hwa_start__ = .;  /* create symbol for start of section */
-	  *(*HWA*)            /* keep my variable even if not referenced */
-	  __hwa_end__ = .;   /* create symbol for end of section */
-	} > HWA
 
 	.bss :
 	{
@@ -123,18 +114,6 @@ SECTIONS
         __rtos_end__ = .;
         _ertos = __rtos_end__;
     } > ram
-
-    /* SPI shared addresses are fixed: */
-    .BLE_SPI_TX_LOCATION 0x20063800 (NOLOAD) :
-    {
-        . = ALIGN(4);
-        KEEP(*(.BLE_SPI_TX_LOCATION)) /* keep it even if not referenced */
-    } > spiram
-    .BLE_SPI_RX_LOCATION  0x20063C00 (NOLOAD) :
-    {
-        . = ALIGN(4);
-        KEEP(*(.BLE_SPI_RX_LOCATION)) /* keep it even if not referenced */
-    } > spiram
 
 	.heap (COPY):
 	{

--- a/qorc_fpga_breathectrl/Makefile
+++ b/qorc_fpga_breathectrl/Makefile
@@ -1,10 +1,11 @@
-# simple makefile wrapper
+# simple makefile wrapper for QORC SDK projects
 SHELL:=bash
 
+# for all targets, check whether the QORC SDK environment has been setup first.
 ifndef QORC_SDK_PATH
 $(info )
 $(info QORC_SDK_PATH is not set in the environment, is the QORC SDK initialized?)
-$(info initialize with: source envsetup.sh from the QORC SDK directory in the current shell)
+$(info initialize with: 'source envsetup.sh' from the QORC SDK directory in the current shell)
 $(info )
 $(error QORC_SDK_PATH not defined)
 endif
@@ -20,22 +21,22 @@ clean: clean-fpga clean-m4
 
 .PHONY: m4
 m4:
-	$(MAKE) -C GCC_Project
+	@$(MAKE) -C GCC_Project
 
 
 .PHONY: clean-m4
 clean-m4:
-	$(MAKE) -C GCC_Project clean
+	@$(MAKE) -C GCC_Project clean
 
 
 .PHONY: fpga
 fpga:
-	.scaffolding/build_fpga.sh
+	@$(MAKE) -C fpga
 
 
 .PHONY: clean-fpga
 clean-fpga:
-	.scaffolding/clean_fpga.sh
+	@$(MAKE) -C fpga clean
 
 
 .PHONY: load-jlink
@@ -48,10 +49,20 @@ load-jlink:
 # or
 # 2. pass in value while invoking: make load-openocd QORC_OCD_IF_CFG=/path/to/cfg
 # default fallback, if not specified, is to assume a JLink adapter, with the cfg file in the .scaffolding dir
-QORC_OCD_IF_CFG?=.scaffolding/jlink_swd.cfg
+QORC_OCD_IF_CFG?=
 .PHONY: load-openocd
 load-openocd:
-	.scaffolding/load_fpga_m4_openocd_gdb.sh --openocd-if-cfg=$(QORC_OCD_IF_CFG)
+	@{ \
+	if [ -z $$QORC_OCD_IF_CFG ] ; then \
+		printf "\nERROR: QORC_OCD_IF_CFG not defined\n\n" ;\
+		printf "    use: 'QORC_OCD_IF_CFG=/path/to/cfg', before invoking make $@\n" ;\
+		printf "    >>OR<<\n" ;\
+		printf "    use 'make $@ QORC_OCD_IF_CFG=/port/name'\n\n" ;\
+		exit 1 ;\
+	else \
+		.scaffolding/load_fpga_m4_openocd_gdb.sh --openocd-if-cfg=$(QORC_OCD_IF_CFG) ;\
+	fi \
+	}
 
 
 # QORC_PORT is used, to be able to flash using the correct serial port.
@@ -64,12 +75,11 @@ flash:
 	@{ \
 	if [ -z $$QORC_PORT ] ; then \
 		printf "\nERROR: QORC_PORT not defined\n\n" ;\
-		printf "    use: 'QORC_PORT=/port/name', before invoking make flash\n" ;\
+		printf "    use: 'QORC_PORT=/port/name', before invoking make $@\n" ;\
 		printf "    >>OR<<\n" ;\
-		printf "    use 'make flash QORC_PORT=/port/name'\n\n" ;\
+		printf "    use 'make $@ QORC_PORT=/port/name'\n\n" ;\
 		exit 1 ;\
 	else \
 		.scaffolding/flash_fpga_m4.sh --port=$(QORC_PORT) ;\
 	fi \
 	}
-

--- a/qorc_fpga_breathectrl/Makefile
+++ b/qorc_fpga_breathectrl/Makefile
@@ -1,0 +1,75 @@
+# simple makefile wrapper
+SHELL:=bash
+
+ifndef QORC_SDK_PATH
+$(info )
+$(info QORC_SDK_PATH is not set in the environment, is the QORC SDK initialized?)
+$(info initialize with: source envsetup.sh from the QORC SDK directory in the current shell)
+$(info )
+$(error QORC_SDK_PATH not defined)
+endif
+
+
+.PHONY: all
+all: fpga m4
+
+
+.PHONY: clean
+clean: clean-fpga clean-m4
+
+
+.PHONY: m4
+m4:
+	$(MAKE) -C GCC_Project
+
+
+.PHONY: clean-m4
+clean-m4:
+	$(MAKE) -C GCC_Project clean
+
+
+.PHONY: fpga
+fpga:
+	.scaffolding/build_fpga.sh
+
+
+.PHONY: clean-fpga
+clean-fpga:
+	.scaffolding/clean_fpga.sh
+
+
+.PHONY: load-jlink
+load-jlink:
+	.scaffolding/load_fpga_m4_jlink.sh
+
+
+# QORC_OCD_IF_CFG is used, to be able to use the correct (interface) debug adapter config in OpenOCD
+# 1. set QORC_OCD_IF_CFG=/path/to/cfg in shell env, before invoking make load-openocd (recommended, needed only once)
+# or
+# 2. pass in value while invoking: make load-openocd QORC_OCD_IF_CFG=/path/to/cfg
+# default fallback, if not specified, is to assume a JLink adapter, with the cfg file in the .scaffolding dir
+QORC_OCD_IF_CFG?=.scaffolding/jlink_swd.cfg
+.PHONY: load-openocd
+load-openocd:
+	.scaffolding/load_fpga_m4_openocd_gdb.sh --openocd-if-cfg=$(QORC_OCD_IF_CFG)
+
+
+# QORC_PORT is used, to be able to flash using the correct serial port.
+# 1. set QORC_PORT in shell env, before invoking make flash (recommended, needed only once)
+# or
+# 2. pass in the value while invoking make flash like so: make flash QORC_PORT=/dev/ttyPORTNAME
+QORC_PORT?=
+.PHONY: flash
+flash:
+	@{ \
+	if [ -z $$QORC_PORT ] ; then \
+		printf "\nERROR: QORC_PORT not defined\n\n" ;\
+		printf "    use: 'QORC_PORT=/port/name', before invoking make flash\n" ;\
+		printf "    >>OR<<\n" ;\
+		printf "    use 'make flash QORC_PORT=/port/name'\n\n" ;\
+		exit 1 ;\
+	else \
+		.scaffolding/flash_fpga_m4.sh --port=$(QORC_PORT) ;\
+	fi \
+	}
+

--- a/qorc_fpga_breathectrl/README.rst
+++ b/qorc_fpga_breathectrl/README.rst
@@ -155,7 +155,7 @@ Before clean/build/load/flash, ensure that the bash environment is setup by doin
 
    ::
 
-     cd <QORC_SDK_PATH> && source envsetup.sh && cd -
+     source <QORC_SDK_PATH>/envsetup.sh
 
 
 Clean/Build/Load/Flash (Command Line)
@@ -163,19 +163,27 @@ Clean/Build/Load/Flash (Command Line)
 
 - Clean using:
 
-  fpga: :code:`.scaffolding/clean_fpga.sh`
+  fpga: :code:`make clean-fpga`
 
-  m4: :code:`make -C GCC_Project/ clean`
+  m4: :code:`make clean-m4`
+
+  both: :code:`make clean`
 
 - Build using:
 
-  fpga: :code:`.scaffolding/build_fpga.sh`
+  fpga: :code:`make fpga`
 
-  m4: :code:`make -C GCC_Project/`
+  m4: :code:`make m4`
 
-- Load and run the design on the board using JLinkExe, using: :code:`.scaffolding/load_fpga_m4_jlink.sh`
+  both: :code:`make`
+
+- Load and run the design on the board using JLinkExe, using:
 
   (assumes the board has been booted in DEBUG mode)
+
+  ::
+      
+    make load-jlink
 
 - Load and run the design on the board using OpenOCD, using:
 
@@ -183,24 +191,30 @@ Clean/Build/Load/Flash (Command Line)
 
   ::
 
-    .scaffolding/load_fpga_m4_openocd_gdb.sh --openocd-if-cfg=<PATH_TO_INTERFACE_CFG>
+    export QORC_OCD_IF_CFG=/path/to/inteface/cfg    # needs to be done only once in the current shell
+    make load-openocd
 
-  The INTERFACE_CFG file depends on the debug adapter chosen.
+  The interface cfg file depends on the debug adapter chosen.
 
   Here are a few common adapters that can be used with the EOS_S3:
   
-  1. JLink Adapters: :code:`--openocd-if-cfg=.scaffolding/jlink_swd.cfg` (available in the current dir)
-  2. FT2232H Boards: :code:`--openocd-if-cfg=.scaffolding/ft2232h_swd.cfg` (available in the current dir)
-  3. STLinkv2 Adapters: :code:`--openocd-if-cfg=interface/stlink-v2.cfg` (available in the OpenOCD install scripts dir)
-  4. DAPLink Adapters: :code:`--openocd-if-cfg=interface/cmsis-dap.cfg` (available in the OpenOCD install scripts dir)
+  1. JLink Adapters: :code:`export QORC_OCD_IF_CFG=.scaffolding/jlink_swd.cfg` (available in the current dir)
+  2. FT2232H Boards: :code:`export QORC_OCD_IF_CFG=.scaffolding/ft2232h_swd.cfg` (available in the current dir)
+  3. STLinkv2 Adapters: :code:`export QORC_OCD_IF_CFG=interface/stlink-v2.cfg` (available in the OpenOCD install scripts dir)
+  4. DAPLink Adapters: :code:`export QORC_OCD_IF_CFG=interface/cmsis-dap.cfg` (available in the OpenOCD install scripts dir)
 
   Practically, any adapter that supports OpenOCD and SWD can be used with the appropriate cfg file passed in.
 
-- Flash and run the design on the board using qfprog: :code:`.scaffolding/flash_fpga_m4.sh --port=/dev/ttyACM0`
+- Flash and run the design on the board using qfprog:
   
   (assumes the board is put into :code:`programming` mode)
 
-  Change the serial port as applicable.
+  ::
+
+    export QORC_PORT=/path/to/serial/port   # needs to be done only once in current shell
+    make flash
+
+  Set the serial port as applicable, this is generally :code:`export QORC_PORT=/dev/ttyACM0`
 
 
 VS Code Usage
@@ -235,7 +249,8 @@ The first time the project is going to be used from VS Code, we need to do the f
 
    - To be able to 'debug' the code with gdb, remember to install the extension: :code:`marus25.cortex-debug`
 
-   On opening the folder, VS Code should prompt to install "recommended extensions" and this can install them automatically.
+   On opening the folder, VS Code should prompt to install these "recommended extensions", if not already installed, 
+   select :code:`Install All` to automatically install them.
 
 
 Clean/Build/Load/Flash (VS Code)
@@ -263,18 +278,18 @@ Using keyboard shortcuts: :code:`ctrl+p` and then type :code:`task<space>`, whic
   
   (assumes the board has been booted in DEBUG mode)
 
-  :code:`load-fpga-m4 (JLink)` task
+  :code:`load (JLink)` task
 
 - Load and run the design on the board using OpenOCD, using:
 
   (assumes the board has been booted in DEBUG mode)
 
-  :code:`load-fpga-m4 (OpenOCD)` task
+  :code:`load (OpenOCD)` task
 
   This will show a drop down menu with the options of debug adapters currently tested:
 
-  - JLink Adapters :code:`jlink_swd.cfg`
-  - FT2232H Boards :code:`ft2232h_swd.cfg`
+  - JLink Adapters :code:`.scaffolding/jlink_swd.cfg`
+  - FT2232H Boards :code:`.scaffolding/ft2232h_swd.cfg`
   - STLinkv2 Adapters :code:`interface/stlink-v2.cfg`
   - DAPLink Adapters :code:`interface/cmsis-dap.cfg`
 
@@ -284,13 +299,13 @@ Using keyboard shortcuts: :code:`ctrl+p` and then type :code:`task<space>`, whic
 
   (assumes the board is put into :code:`programming` mode)
 
-  :code:`flash-fpga-m4` task
+  :code:`flash` task
 
   This will show a drop down menu with the available serial ports in the system, select the appropriate one.
   
   (This is usually :code:`/dev/ttyACM0`)
 
-- :code:`debug-load-fpga (JLink)` : this is a special task used only while debugging the code with JLink.
+- :code:`debug-load-fpga (JLink)` : this is a special task required only while debugging the code with JLink.
 
   Refer to the Debug sections for details.
 
@@ -323,8 +338,8 @@ Debug
   
   4. A drop-down menu appears to select the debug adapter being used, currently the choices are:
    
-     - :code:`jlink_swd.cfg`
-     - :code:`ft2232h_swd.cfg`
+     - :code:`.scaffolding/jlink_swd.cfg`
+     - :code:`.scaffolding/ft2232h_swd.cfg`
      - :code:`interface/stlink-v2.cfg`
      - :code:`interface/cmsis-dap.cfg`
 

--- a/qorc_fpga_breathectrl/README.rst
+++ b/qorc_fpga_breathectrl/README.rst
@@ -144,7 +144,7 @@ How To
 Command Line Usage
 ~~~~~~~~~~~~~~~~~~
 
-Note that, all the commands below are run from the root of this directory.
+:code:`Note: all the commands below are run from the root of this directory.`
 
 Initialize Environment
 **********************

--- a/qorc_fpga_breathectrl/README.rst
+++ b/qorc_fpga_breathectrl/README.rst
@@ -151,7 +151,7 @@ Initialize Environment
 
 Before clean/build/load/flash, ensure that the bash environment is setup by doing the below:
 
-1. Ensure that QORC-SDK is initialized and ready (to use :code:`JLinkExe` or :code:`OpenOCD` for loading, :code:`qfprog` for flashing):
+1. Ensure that QORC-SDK is initialized and ready:
 
    ::
 

--- a/qorc_fpga_breathectrl/fpga/Makefile
+++ b/qorc_fpga_breathectrl/fpga/Makefile
@@ -1,0 +1,70 @@
+# simple makefile wrapper for QORC SDK project FPGA build
+SHELL:=bash
+
+# for all targets, check whether the QORC SDK environment has been setup first.
+ifndef QORC_SDK_PATH
+$(info )
+$(info QORC_SDK_PATH is not set in the environment, is the QORC SDK initialized?)
+$(info initialize with: 'source envsetup.sh' from the QORC SDK directory in the current shell)
+$(info )
+$(error QORC_SDK_PATH not defined)
+endif
+
+
+# we should be squatting in the 'fpga' dir
+export QORC_FPGA_DIR=$(shell pwd)
+export QORC_FPGA_RTL_DIR=$(QORC_FPGA_DIR)/rtl
+
+
+# "top" module name : change as per the project
+export QORC_FPGA_TOP_MODULE=AL4S3B_FPGA_Top
+
+# PD64/PU64/WR42 : choose the package as per the project
+export QORC_FPGA_PACKAGE=PU64
+
+# if there are multiple .pcf files, we take the first one by default
+# if this is already defined by user in the current environment, we use that instead.
+export QORC_FPGA_PCF_FILE?=$(notdir $(firstword $(wildcard $(QORC_FPGA_RTL_DIR)/*.pcf)))
+
+# device is fixed, ql-eos-s3
+export QORC_FPGA_DEVICE=ql-eos-s3
+
+# get the RTL source file (paths) - all verilog files in the fpga/rtl directory
+FPGA_RTL_SRC_PATHS:=$(wildcard $(QORC_FPGA_RTL_DIR)/*.v)
+# file-names only
+FPGA_RTL_SRCS:=$(notdir $(FPGA_RTL_SRC_PATHS))
+# filter-out some files, enable if needed
+#filters=
+#FPGA_RTL_SRCS:=$(filter-out $(filters),$(FPGA_RTL_SRCS))
+ifeq ($(FPGA_RTL_SRCS),)
+$(error No FPGA RTL Sources Found in $(QORC_FPGA_RTL_DIR))
+else
+# define the target for the build as the generated FPGA binary
+FPGA_RTL_BIN_OBJ:=$(QORC_FPGA_TOP_MODULE).bin
+endif
+
+$(info )
+$(info top: $(QORC_FPGA_TOP_MODULE))
+$(info rtl-dir: $(QORC_FPGA_RTL_DIR))
+$(info rtl-file-names: $(FPGA_RTL_SRCS))
+#$(info rtl-file-paths: $(FPGA_RTL_SRC_PATHS))
+$(info pcf: $(QORC_FPGA_PCF_FILE))
+#$(info bin : $(FPGA_RTL_BIN_OBJ))
+$(info )
+
+.PHONY: all
+all: $(FPGA_RTL_BIN_OBJ)
+
+$(FPGA_RTL_BIN_OBJ): $(FPGA_RTL_SRC_PATHS)
+	@time ql_symbiflow -compile -src $(QORC_FPGA_RTL_DIR) -d $(QORC_FPGA_DEVICE) -t $(QORC_FPGA_TOP_MODULE) -v $(FPGA_RTL_SRCS) -p $(QORC_FPGA_PCF_FILE) -P $(QORC_FPGA_PACKAGE) -dump binary openocd jlink
+
+
+
+.PHONY: clean
+clean:
+	@rm -r $(QORC_FPGA_RTL_DIR)/build 				2> /dev/null || true
+	@rm $(QORC_FPGA_RTL_DIR)/*bit.h 				2> /dev/null || true
+	@rm $(QORC_FPGA_RTL_DIR)/*.bin 					2> /dev/null || true
+	@rm $(QORC_FPGA_RTL_DIR)/*.jlink 				2> /dev/null || true
+	@rm $(QORC_FPGA_RTL_DIR)/*.openocd 				2> /dev/null || true
+	@rm $(QORC_FPGA_RTL_DIR)/Makefile.symbiflow 	2> /dev/null || true


### PR DESCRIPTION
makefile support:

- build/clean m4
- build/clean fpga
- build/clean both
- load using JLink
- load using OpenOCD
- flash

This makes it more standardized, so usage is familiar for users of other embedded ecosystems.